### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# termoshtt/stack docker image [![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg?maxAge=2592000?style=plastic)](https://hub.docker.com/r/termoshtt/stack/)
+# termoshtt/stack docker image [![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg?maxAge=2592000?style=plastic)](https://hub.docker.com/r/termoshtt/stack/) [![](https://images.microbadger.com/badges/image/termoshtt/stack.svg)](https://microbadger.com/images/termoshtt/stack "Get your own image badge on microbadger.com")
 Docker image for haskell/stack with my favarite modules
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [termoshtt/stack](https://hub.docker.com/r/termoshtt/stack/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/termoshtt/stack).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/termoshtt/stack.svg)](https://microbadger.com/images/termoshtt/stack)
